### PR TITLE
Adjust current based on scalar from firmware

### DIFF
--- a/esphome/components/emporia_vue/emporia_vue.cpp
+++ b/esphome/components/emporia_vue/emporia_vue.cpp
@@ -107,14 +107,14 @@ void CTClampConfig::update_from_reading(const SensorReading &sensor_reading) {
   }
   if (this->current_sensor_) {
     uint16_t raw_current = sensor_reading.current[this->input_port_];
-    double raw_current_d = (double)raw_current;
+    double raw_current_d = (double) raw_current;
     double scalar;
-    if(this->input_port_ <= CTInputPort::C) {
+    if (this->input_port_ <= CTInputPort::C) {
       scalar = 0.018182244744744745d;
     } else {
       scalar = 0.004545561186186186d;
     }
-    this->current_sensor_->publish_state(raw_current_d*scalar);
+    this->current_sensor_->publish_state(raw_current_d * scalar);
   }
 }
 

--- a/esphome/components/emporia_vue/emporia_vue.cpp
+++ b/esphome/components/emporia_vue/emporia_vue.cpp
@@ -110,9 +110,9 @@ void CTClampConfig::update_from_reading(const SensorReading &sensor_reading) {
     double raw_current_d = (double) raw_current;
     double scalar;
     if (this->input_port_ <= CTInputPort::C) {
-      scalar = 0.018182244744744745d;
+      scalar = 775.0 / 42624.0;
     } else {
-      scalar = 0.004545561186186186d;
+      scalar = 775.0 / 170496.0;
     }
     this->current_sensor_->publish_state(raw_current_d * scalar);
   }

--- a/esphome/components/emporia_vue/emporia_vue.cpp
+++ b/esphome/components/emporia_vue/emporia_vue.cpp
@@ -107,8 +107,14 @@ void CTClampConfig::update_from_reading(const SensorReading &sensor_reading) {
   }
   if (this->current_sensor_) {
     uint16_t raw_current = sensor_reading.current[this->input_port_];
-    // we don't know how this sensor is calibrated by the original firmware
-    this->current_sensor_->publish_state(raw_current);
+    double raw_current_d = (double)raw_current;
+    double scalar;
+    if(this->input_port_ <= CTInputPort::C) {
+      scalar = 0.018182244744744745d;
+    } else {
+      scalar = 0.004545561186186186d;
+    }
+    this->current_sensor_->publish_state(raw_current_d*scalar);
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the current correct value that is found in the original firmware. This adjustment value is different for CT clamps A,B, and C than the rest of the clamps.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
