### PR TITLE
Add comment to setup timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ i2c:
 time:
   - platform: sntp
     id: my_time
-
+    # Adjust to your local timezone.  Impacts on when day is wrapped for daily energy calculations
+    timezone: 'America/Los_Angeles'
+    
 # these are called references in YAML. They allow you to reuse
 # this configuration in each sensor, while only defining it once
 .defaultfilters:


### PR DESCRIPTION
If timezone is not added, daily energy calculations will wrap at. a wrong hour.

# What does this implement/fix?

Added configuration item to set proper timezone.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
