### PR TITLE
update FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Note the `sliding_window_moving_average`. This is optional, but since we get a r
 
 Note the "Total Power", "Total Daily Energy", and "Circuit x Daily Energy". This is needed for the Home Assistant energy system, which requires daily kWh numbers.
 
-To configure energy returned to the grid for NET metering ( [more info here](https://www.nrel.gov/state-local-tribal/basics-net-metering.html)), you need to add the following configuration:
+To configure energy returned to the grid for NET metering ([more info here](https://www.nrel.gov/state-local-tribal/basics-net-metering.html)), you need to add the following configuration:
 ```
 sensor:
   - platform: emporia_vue
@@ -276,7 +276,7 @@ sensor:
     accuracy_decimals: 0
 
 ```
-Your solar sensors' configuration depends on your setup (single phase, split phase, 3-phase). The following example shows a split-phase installation using ct clapms 15 and 16:
+Your solar sensors' configuration depends on your setup (single phase, split phase, 3-phase). The following example shows a split-phase installation using ct clamps 15 and 16:
 ```
 sensor:
   - platform: template
@@ -289,6 +289,7 @@ sensor:
     power_id: solar_power
     accuracy_decimals: 0
 ```
+If you made errors in your configuration and your template sensors recorded strange values in home-assistant, you can reset all sensors by implementing a [factory reset button](https://esphome.io/components/button/factory_reset.html).
 
 Do not use the `web_server` since it is not compatible with the `esp-idf` framework, and you will get odd error messages.
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,6 @@ sensor:
     power_id: solar_power
     accuracy_decimals: 0
 ```
-If you made errors in your configuration and your template sensors recorded strange values in home-assistant, you can reset all sensors by implementing a [factory reset button](https://esphome.io/components/button/factory_reset.html).
 
 Do not use the `web_server` since it is not compatible with the `esp-idf` framework, and you will get odd error messages.
 
@@ -351,6 +350,10 @@ There's now support for MQTT with this integration thanks to the hard work of th
 
 - You may have put that clamp on the wire backwards
 - You may have selected the wrong phase in the configuration
+
+### I've recorded negative energy values and I want to reset them
+
+Sensor values are saved to the esp32 flash. You can reset all sensors by implementing a [factory reset button](https://esphome.io/components/button/factory_reset.html).
 
 ### The readings on one or two of my sensors are crazy
 


### PR DESCRIPTION
# What does this implement/fix?

Initially I misconfigured my solar sensors and recorded an arbitrary negative number for daily returned energy. Home-assistant's energy dashboard did not like negative values for an energy sensor. I spent quite some time to figure out how to reset it in home-assistant, and figured that it's stored in the esp32 flash.
This is the easiest way I found to reset the sensor values.

Also, two typos fixed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
