### PR TITLE
Allow update interval to be configured in yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ time:
 sensor:
   - platform: emporia_vue
     i2c_id: i2c_a
+    update_interval: 240ms  # If you have a revision 5 Emporia Vue 2, use 500ms instead
     phases:
       - id: phase_a  # Verify that this specific phase/leg is connected to correct input wire color on device listed below
         input: BLACK  # Vue device wire color

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ time:
 sensor:
   - platform: emporia_vue
     i2c_id: i2c_a
-    update_interval: 240ms  # If you have a revision 5 Emporia Vue 2, use 500ms instead
     phases:
       - id: phase_a  # Verify that this specific phase/leg is connected to correct input wire color on device listed below
         input: BLACK  # Vue device wire color

--- a/esphome/components/emporia_vue/emporia_vue.h
+++ b/esphome/components/emporia_vue/emporia_vue.h
@@ -40,8 +40,6 @@ class CTClampConfig;
 
 class EmporiaVueComponent : public PollingComponent, public i2c::I2CDevice {
  public:
-  EmporiaVueComponent() : PollingComponent(240 /* ms */) {}
-
   void dump_config() override;
 
   float get_setup_priority() const override { return esphome::setup_priority::HARDWARE; }

--- a/esphome/components/emporia_vue/sensor.py
+++ b/esphome/components/emporia_vue/sensor.py
@@ -33,7 +33,7 @@ AUTO_LOAD = ["sensor"]
 
 emporia_vue_ns = cg.esphome_ns.namespace("emporia_vue")
 EmporiaVueComponent = emporia_vue_ns.class_(
-    "EmporiaVueComponent", cg.Component, i2c.I2CDevice
+    "EmporiaVueComponent", cg.PollingComponent, i2c.I2CDevice
 )
 PhaseConfig = emporia_vue_ns.class_("PhaseConfig")
 CTClampConfig = emporia_vue_ns.class_("CTClampConfig")
@@ -150,7 +150,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_CT_CLAMPS): cv.ensure_list(SCHEMA_CT_CLAMP),
         },
     )
-    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.polling_component_schema("240ms"))
     .extend(i2c.i2c_device_schema(0x64)),
     cv.only_with_esp_idf,
     cv.only_on_esp32,

--- a/esphome/components/emporia_vue/sensor.py
+++ b/esphome/components/emporia_vue/sensor.py
@@ -150,7 +150,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_CT_CLAMPS): cv.ensure_list(SCHEMA_CT_CLAMP),
         },
     )
-    .extend(cv.polling_component_schema("240ms"))
+    .extend(cv.polling_component_schema("0ms"))
     .extend(i2c.i2c_device_schema(0x64)),
     cv.only_with_esp_idf,
     cv.only_on_esp32,


### PR DESCRIPTION
This small change allows you to set the update interval using YAML (as revision 5 hardware only updates every 500ms versus the default 240ms, see https://github.com/emporia-vue-local/esphome/discussions/89). It still uses 240ms by default, so it should not be a breaking change for anyone. Note that the default configuration filters should be adjusted as appropriate to match your desired behavior.

For a revision 5 Emporia Vue 2, use the following:
```

sensor:
  - platform: emporia_vue
    update_interval: 500ms
    i2c_id: i2c_a
    phases:
      ...

```