### PR TITLE
Reduce log levels to warnings in example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ ota:
   # Create a secure password for pushing OTA updates.
   password: "<secure_password>"
 
-# Enable logging
+# Enable logging of warnings
 logger:
+  baud_rate: 0  # disable sending logs over UART
+  level: WARN
 
 wifi:
   # Wifi credentials are stored securely by new device wizard.


### PR DESCRIPTION
This PR lowers the log level to only output messages at the warning or worse level instead of the default debug level. This should reduce the amount of log activity (especially after PR #200). Larger issues should still be logged at this level. Also, it sets the ``baud_rate`` to 0 so that logs are no longer sent to the UART interface. This can also improve performance, and I imagine most people are not leaving the UART hooked up after the initial flashing of the ESP32. Between these two changes, the warnings about slow component updates on recent ESPHome versions should be very rare.

Please share any concerns about changing to this log level.