### PR TITLE
Document potential Apple Silicon issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ If your TTL adapter has both the DTR and RTS pins exposed, you can let it automa
 
 With your other hand, run the following in the console: `esptool.py -b 921600 read_flash 0 0x800000 flash_contents.bin`. Successful completion of this step is _critical_ in case something goes wrong later. This file is necessary to restore the device to factory function.
 
-If the above command fails, try again using `esptool.py -b 115200 read_flash 0 0x800000 flash_contents.bin`.
+If the above command fails, try again using `esptool.py -b 115200 read_flash 0 0x800000 flash_contents.bin`. If you're using an Apple Silicon (M1, M2, etc) CPU and it stops working after a certain percentage every time, try using a different machine
 
 ### Flashing new software
 


### PR DESCRIPTION
After lots of time troubleshooting what could be going wrong with flashing this device, I discovered that switching the host from an M1 mac to a generic linux device made everything work fine. This PR documents what I saw, very briefly, which will hopefully help anyone else from dealing with the same issue I dealt with