### PR TITLE
Add 'frequency_calibration' parameter for vue3

### DIFF
--- a/esphome/components/emporia_vue/emporia_vue.cpp
+++ b/esphome/components/emporia_vue/emporia_vue.cpp
@@ -93,7 +93,7 @@ void PhaseConfig::update_from_reading(const SensorReading &sensor_reading) {
   // validation that these sensors are allowed on this phase is done in the codegen stage
   if (this->frequency_sensor_) {
     // see https://github.com/emporia-vue-local/esphome/pull/88 for constant explanation
-    float frequency = 25310.0f / (float) raw_frequency;
+    float frequency = (25310.0f / (float) raw_frequency) * this->frequency_calibration_;
     this->frequency_sensor_->publish_state(frequency);
   }
   if (this->phase_angle_sensor_) {

--- a/esphome/components/emporia_vue/emporia_vue.h
+++ b/esphome/components/emporia_vue/emporia_vue.h
@@ -72,6 +72,8 @@ class PhaseConfig {
   float get_calibration() const { return this->calibration_; }
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { this->voltage_sensor_ = voltage_sensor; }
   sensor::Sensor *get_voltage_sensor() const { return this->voltage_sensor_; }
+  void set_frequency_calibration(float calibration) { this->frequency_calibration_ = calibration; }
+  float get_freqency_calibration() const { return this->frequency_calibration_; }
   void set_frequency_sensor(sensor::Sensor *frequency_sensor) { this->frequency_sensor_ = frequency_sensor; }
   sensor::Sensor *get_frequency_sensor() const { return this->frequency_sensor_; }
   void set_phase_angle_sensor(sensor::Sensor *phase_angle_sensor) { this->phase_angle_sensor_ = phase_angle_sensor; }
@@ -84,6 +86,7 @@ class PhaseConfig {
  protected:
   PhaseInputWire input_wire_;
   float calibration_;
+  float frequency_calibration_;
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *frequency_sensor_{nullptr};
   sensor::Sensor *phase_angle_sensor_{nullptr};

--- a/esphome/components/emporia_vue/sensor.py
+++ b/esphome/components/emporia_vue/sensor.py
@@ -27,6 +27,7 @@ from esphome.const import (
 CONF_CT_CLAMPS = "ct_clamps"
 CONF_PHASES = "phases"
 CONF_PHASE_ID = "phase_id"
+CONF_FREQUENCY_CALIBRATION = "frequency_calibration"
 
 CONF_ON_UPDATE = "on_update"
 
@@ -104,6 +105,7 @@ def validate_phases(val):
                 cv.Required(CONF_ID): cv.declare_id(PhaseConfig),
                 cv.Required(CONF_INPUT): cv.enum(PHASE_INPUT),
                 cv.Optional(CONF_CALIBRATION, default=0.022): cv.zero_to_one_float,
+                cv.Optional(CONF_FREQUENCY_CALIBRATION, default=1.0): cv.zero_to_one_float,
                 cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
                     unit_of_measurement=UNIT_VOLT,
                     device_class=DEVICE_CLASS_VOLTAGE,
@@ -184,6 +186,7 @@ async def to_code(config):
         phase_var = cg.new_Pvariable(phase_config[CONF_ID], PhaseConfig())
         cg.add(phase_var.set_input_wire(phase_config[CONF_INPUT]))
         cg.add(phase_var.set_calibration(phase_config[CONF_CALIBRATION]))
+        cg.add(phase_var.set_frequency_calibration(phase_config[CONF_FREQUENCY_CALIBRATION]))
 
         if CONF_VOLTAGE in phase_config:
             voltage_sensor = await sensor.new_sensor(phase_config[CONF_VOLTAGE])


### PR DESCRIPTION
The vue3 requires a different calibration factor for frequency than the vue2.  The current code has the frequency calibration parameter hardcoded.

This adds `frequency_calibration` as a parameter similar to the volatge `calibration` parameter.  It only needs to be specified for the 'A' phase, though it should work fine if specified on all phases.

On the Vue3 at 60Hz, the proper configuration parameter seems to be:
```
sensor:
  - platform: emporia_vue
    phases:
      - id: phase_a  # Verify that this specific phase/leg is connected to correct input wire color on device listed below
        input: BLACK  # Vue device wire color
        calibration: 0.0194  # 0.022 is used as the default as starting point but may need adjusted to ensure accuracy
        frequency_calibration: 0.77022  # Vue3 uses a different calibration value (only needed for phase A)
```