### PR TITLE
skip 2 errors in a row without posting a log entry

### DIFF
--- a/esphome/components/emporia_vue/emporia_vue.cpp
+++ b/esphome/components/emporia_vue/emporia_vue.cpp
@@ -6,6 +6,7 @@ namespace esphome {
 namespace emporia_vue {
 
 static const char *const TAG = "emporia_vue";
+static const int ESP_READ_SKIP_ERRORS = 2;
 
 void EmporiaVueComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Emporia Vue");
@@ -49,10 +50,16 @@ void EmporiaVueComponent::update() {
     return;
   }
 
+  static int sensor_reading_end_errorcount = 0;
   if (sensor_reading.end != 0) {
-    ESP_LOGE(TAG, "Failed to read from sensor due to a malformed reading, should end in null bytes but is %d",
-             sensor_reading.end);
+    ++sensor_reading_end_errorcount;
+    if (sensor_reading_end_errorcount > ESP_READ_SKIP_ERRORS) {
+      ESP_LOGE(TAG, "Failed to read from sensor due to a malformed reading, should end in null bytes but is %d",
+               sensor_reading.end);
+    }
     return;
+  } else {
+    sensor_reading_end_errorcount = 0;
   }
 
   if (!sensor_reading.is_unread) {


### PR DESCRIPTION
Using this code on vue3 device. I'm noticing that there are errors "Failed to read from sensor due to a malformed reading, should end in null bytes but is xxx" in the log, which are quite benign if they don't repeat

This code change is to skip this logging message if there's 2 or fewer errors in a row.