### PR TITLE
Update README.md with new recommended i2c settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ i2c:
   sda: 21
   scl: 22
   scan: false
-  frequency: 200kHz  # recommended range is 50-200kHz
+  frequency: 400kHz
+  timeout: 1ms
   id: i2c_a
 
 time:


### PR DESCRIPTION
This is necessary to work with esphome version 2024.10.0. See https://github.com/esphome/issues/issues/6335 and https://github.com/emporia-vue-local/esphome/discussions/108.