### PR TITLE
Recommend homeassistant for time over sntp

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ i2c:
   id: i2c_a
 
 time:
-  - platform: sntp
+  # needs some time source to reset daily counters and not accumulate
+  # floating-point issues. If Home Assistant isn't available, use sntp and
+  # set servers and/or DNS as appropriate: https://esphome.io/components/time/sntp.html
+  - platform: homeassistant
     id: my_time
 
 # these are called references in YAML. They allow you to reuse


### PR DESCRIPTION
Where Home Assistant is available (likely the wide majority of ESPHome users), this sets time without needing to go to the internet or have DNS servers set, which resolves a few issues with daily resets (and accumulated floating point errors) and eliminates external network access.

In combination with an earlier configuration that left the `total_daily_energy` sensors being persisted to flash, I had ended up with over 23 MWh in my total energy counts, leading to lots of floating point issues.

This was also the resolution in https://github.com/emporia-vue-local/esphome/discussions/248#discussioncomment-8014845 and #175, so I figured I'd make a PR to change the default to getting time from Home Assistant.

If you think that's not appropriate because you expect people will generally use ESPHome standalone instead, feel free to close this PR, although some notes in the recommended config to a similar effect would probably be useful.