### PR TITLE
feat(emporia_vue): allow variant specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For issues, please go to [the discussion board](https://github.com/emporia-vue-l
 
 # Setting up Emporia Vue 2 with ESPHome
 
-**Got a Vue 3? [You can install ESPHome local control on it as well!](https://digiblur.com/2024/03/14/emporia-vue-gen3-esp32-esphome-home-assistant/)**
+**Got a Vue 3? [You can install ESPHome local control on it as well!](https://digiblur.com/2024/03/14/emporia-vue-gen3-esp32-esphome-home-assistant/)** Set `variant: vue3` in the `emporia_vue` sensor block when compiling for Gen 3 hardware.
 
 ![example of hass setup](https://i.imgur.com/hC26j2M.png)
 
@@ -172,6 +172,8 @@ time:
 
 sensor:
   - platform: emporia_vue
+    # Set the hardware revision. Default is Vue 2; use "vue3" for the Gen 3 hardware
+    variant: vue2
     i2c_id: i2c_a
     phases:
       - id: phase_a  # Verify that this specific phase/leg is connected to correct input wire color on device listed below
@@ -310,6 +312,8 @@ sensor:
   - { power_id: cir15, platform: total_daily_energy, accuracy_decimals: 0, restore: false, name: "Circuit 15 Daily Energy", filters: *throttle_time }
   - { power_id: cir16, platform: total_daily_energy, accuracy_decimals: 0, restore: false, name: "Circuit 16 Daily Energy", filters: *throttle_time }
 ```
+
+**Vue 3 hardware:** Change `variant: vue2` above to `variant: vue3` (value is case-insensitive). Vue 2 units can leave the line as-is or delete it entirely to use the default.
 
 You'll want to replace `<ota password>`, `<wifi ssid>`, and `<wifi password>` with a unique password, and your wifi credentials, respectively.
 

--- a/esphome/components/emporia_vue/emporia_vue.cpp
+++ b/esphome/components/emporia_vue/emporia_vue.cpp
@@ -7,8 +7,19 @@ namespace emporia_vue {
 
 static const char *const TAG = "emporia_vue";
 
+#if defined(EMPORIA_VUE_VARIANT_VUE3)
+static constexpr float EMPORIA_VUE_FREQUENCY_CONSTANT = 19610.0f;
+#else
+static constexpr float EMPORIA_VUE_FREQUENCY_CONSTANT = 25310.0f;
+#endif
+
 void EmporiaVueComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Emporia Vue");
+#if defined(EMPORIA_VUE_VARIANT_VUE3)
+  ESP_LOGCONFIG(TAG, "  Variant: Vue 3");
+#else
+  ESP_LOGCONFIG(TAG, "  Variant: Vue 2");
+#endif
   LOG_I2C_DEVICE(this);
 
   for (auto *phase : this->phases_) {
@@ -83,6 +94,10 @@ void EmporiaVueComponent::add_on_update_callback(std::function<void()> &&callbac
   this->callback_.add(std::move(callback));
 }
 
+static inline bool is_mains_port(CTInputPort port) {
+  return port == CTInputPort::A || port == CTInputPort::B || port == CTInputPort::C;
+}
+
 void PhaseConfig::update_from_reading(const SensorReading &sensor_reading) {
   if (this->voltage_sensor_) {
     float calibrated_voltage = sensor_reading.voltage[this->input_wire_] * this->calibration_;
@@ -93,7 +108,7 @@ void PhaseConfig::update_from_reading(const SensorReading &sensor_reading) {
   // validation that these sensors are allowed on this phase is done in the codegen stage
   if (this->frequency_sensor_) {
     // see https://github.com/emporia-vue-local/esphome/pull/88 for constant explanation
-    float frequency = 25310.0f / (float) raw_frequency;
+    float frequency = EMPORIA_VUE_FREQUENCY_CONSTANT / static_cast<float>(raw_frequency);
     this->frequency_sensor_->publish_state(frequency);
   }
   if (this->phase_angle_sensor_) {
@@ -129,7 +144,7 @@ void CTClampConfig::update_from_reading(const SensorReading &sensor_reading) {
     uint16_t raw_current = sensor_reading.current[this->input_port_];
     double raw_current_d = (double) raw_current;
     double scalar;
-    if (this->input_port_ <= CTInputPort::C) {
+    if (is_mains_port(this->input_port_)) {
       scalar = 775.0 / 42624.0;
     } else {
       scalar = 775.0 / 170496.0;

--- a/esphome/components/emporia_vue/emporia_vue.h
+++ b/esphome/components/emporia_vue/emporia_vue.h
@@ -90,9 +90,15 @@ class PhaseConfig {
 };
 
 enum CTInputPort : uint8_t {
+#if defined(EMPORIA_VUE_VARIANT_VUE3)
+  A = 2,
+  B = 1,
+  C = 0,
+#else
   A = 0,
   B = 1,
   C = 2,
+#endif
   ONE = 3,
   TWO = 4,
   THREE = 5,

--- a/esphome/components/emporia_vue/sensor.py
+++ b/esphome/components/emporia_vue/sensor.py
@@ -27,6 +27,7 @@ from esphome.const import (
 CONF_CT_CLAMPS = "ct_clamps"
 CONF_PHASES = "phases"
 CONF_PHASE_ID = "phase_id"
+CONF_VARIANT = "variant"
 
 CONF_ON_UPDATE = "on_update"
 
@@ -158,6 +159,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(EmporiaVueComponent),
             cv.Required(CONF_PHASES): validate_phases,
             cv.Required(CONF_CT_CLAMPS): cv.ensure_list(SCHEMA_CT_CLAMP),
+            cv.Optional(CONF_VARIANT, default="vue2"): cv.one_of("vue2", "vue3", lower=True),
             cv.Optional(CONF_ON_UPDATE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -178,6 +180,11 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
+
+    if config.get(CONF_VARIANT, "vue2") == "vue3":
+        cg.add_define("EMPORIA_VUE_VARIANT_VUE3")
+    else:
+        cg.add_define("EMPORIA_VUE_VARIANT_VUE2")
 
     phases = []
     for phase_config in config[CONF_PHASES]:


### PR DESCRIPTION
The difference between the vue2 (dev branch) and vue3 (vue3 branch) is just a few changes. Instead of separate branches, introduce a `variant` tag to the sensor yaml to generate a compile time define of the variant type, defaulting to `vue2`.