### PR TITLE
Remove ESP-IDF restriction from Emporia Vue sensor

### DIFF
--- a/esphome/components/emporia_vue/sensor.py
+++ b/esphome/components/emporia_vue/sensor.py
@@ -171,7 +171,6 @@ CONFIG_SCHEMA = cv.All(
     )
     .extend(cv.polling_component_schema("0ms"))
     .extend(i2c.i2c_device_schema(0x64)),
-    cv.only_with_esp_idf,
     cv.only_on_esp32,
 )
 


### PR DESCRIPTION
Currently when building with this component and ESPHome 2026.1, the following warning is returned:

```
WARNING cv.only_with_esp_idf was deprecated in 2026.1, will change behavior in 2026.6. ESP32 Arduino builds on top of ESP-IDF, so ESP-IDF features are available in both frameworks. Use cv.only_on_esp32 and/or cv.only_with_arduino instead.
```

This change removes the now unnecessary option to silence the warning.