### PR TITLE
Change default update_interval from 0ms to 1s

### DIFF
--- a/esphome/components/emporia_vue/sensor.py
+++ b/esphome/components/emporia_vue/sensor.py
@@ -169,7 +169,7 @@ CONFIG_SCHEMA = cv.All(
             ),
         },
     )
-    .extend(cv.polling_component_schema("0ms"))
+    .extend(cv.polling_component_schema("1s"))
     .extend(i2c.i2c_device_schema(0x64)),
     cv.only_on_esp32,
 )


### PR DESCRIPTION
`update_interval: 0ms` means "poll as fast as possible". On older ESPHome the scheduler was inefficient enough that a 0ms interval was throttled, so the component ran frequently but not literally every tick. After ESPHome 2026.4.0 the scheduler is efficient enough to actually honor a 0ms interval, which means the main loop gets starved and the watchdog fires. ESPHome 2026.4.1 added a safety net that coerces 0ms to 1ms at runtime (https://github.com/esphome/esphome/pull/15799), so the component still runs, just at 1kHz instead of truly "every tick".

Either way, 0ms is not a great default; nothing here actually needs kilohertz sampling, and the old behavior was only useful as an accident of scheduler overhead.

This switches the default to 1s. Users who want tighter timing can still override via `update_interval:` in YAML.
