### PR TITLE
Add support for NA split-phase circuits

### DIFF
--- a/README.old.md
+++ b/README.old.md
@@ -196,6 +196,15 @@ sensor:
         phase_angle:
           name: "Phase B Phase Angle"
           filters: [*throttle_avg, *pos]
+    # Optional: define virtual phases for North American split-phase 120/240V setups.
+    # Virtual phases combine two physical legs and can be referenced by ct_clamps.phase_id.
+    # Virtual voltage is published as the sum of the two source leg voltages.
+    virtual_phases:
+      - id: phase_ab
+        combine: [phase_a, phase_b]
+        voltage:
+          name: "Phase AB Voltage"
+          filters: [*throttle_avg, *pos]
     ct_clamps:
       # Do not specify a name for any of the power sensors here, only an id. This leaves the power sensors internal to ESPHome.
       # Copy sensors will filter and then send power measurements to HA
@@ -215,14 +224,14 @@ sensor:
       - { phase_id: phase_b, input:  "2", power: { id:  cir2, filters: [ *pos ] } }
       - { phase_id: phase_a, input:  "3", power: { id:  cir3, filters: [ *pos ] } }
       - { phase_id: phase_a, input:  "4", power: { id:  cir4, filters: [ *pos ] } }
-      - { phase_id: phase_a, input:  "5", power: { id:  cir5, filters: [ *pos, multiply: 2 ] } }
-      - { phase_id: phase_a, input:  "6", power: { id:  cir6, filters: [ *pos, multiply: 2 ] } }
-      - { phase_id: phase_a, input:  "7", power: { id:  cir7, filters: [ *pos, multiply: 2 ] } }
+      - { phase_id: phase_ab, input:  "5", power: { id:  cir5, filters: [ *pos ] } }
+      - { phase_id: phase_ab, input:  "6", power: { id:  cir6, filters: [ *pos ] } }
+      - { phase_id: phase_ab, input:  "7", power: { id:  cir7, filters: [ *pos ] } }
       - { phase_id: phase_b, input:  "8", power: { id:  cir8, filters: [ *pos ] } }
       - { phase_id: phase_b, input:  "9", power: { id:  cir9, filters: [ *pos ] } }
       - { phase_id: phase_b, input: "10", power: { id: cir10, filters: [ *pos ] } }
-      - { phase_id: phase_a, input: "11", power: { id: cir11, filters: [ *pos, multiply: 2 ] } }
-      - { phase_id: phase_a, input: "12", power: { id: cir12, filters: [ *pos, multiply: 2 ] } }
+      - { phase_id: phase_ab, input: "11", power: { id: cir11, filters: [ *pos ] } }
+      - { phase_id: phase_ab, input: "12", power: { id: cir12, filters: [ *pos ] } }
       - { phase_id: phase_a, input: "13", power: { id: cir13, filters: [ *pos ] } }
       - { phase_id: phase_a, input: "14", power: { id: cir14, filters: [ *pos ] } }
       - { phase_id: phase_b, input: "15", power: { id: cir15, filters: [ *pos ] } }
@@ -322,6 +331,8 @@ You'll also want to update the `sensor` section of the configuration using the i
 Note the `throttle_avg`. This is optional, but since we get a reading every 240ms, it is helpful to average these readings together so that we don't need to store such dense, noisy, data in Home Assistant.
 
 Note the "Total Power", "Total Daily Energy", and "Circuit x Daily Energy". This is needed for the Home Assistant energy system, which requires daily kWh numbers.
+
+The `virtual_phases` feature is intended for North American split-phase (120/240V) use. It may not produce correct results on 3-phase services or other electrical topologies.
 
 To configure energy returned to the grid for NET metering ([more info here](https://www.nrel.gov/state-local-tribal/basics-net-metering.html)), you need to add the following configuration:
 

--- a/esphome/components/emporia_vue/emporia_vue.cpp
+++ b/esphome/components/emporia_vue/emporia_vue.cpp
@@ -40,10 +40,16 @@ void EmporiaVueComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "    Calibration: %f", phase->get_calibration());
     LOG_SENSOR("    ", "Voltage", phase->get_voltage_sensor());
   }
+  for (auto *virtual_phase : this->virtual_phases_) {
+    ESP_LOGCONFIG(TAG, "  Virtual Phase");
+    ESP_LOGCONFIG(TAG, "    Source Wire A: %d", virtual_phase->get_phase_a()->get_input_wire());
+    ESP_LOGCONFIG(TAG, "    Source Wire B: %d", virtual_phase->get_phase_b()->get_input_wire());
+    LOG_SENSOR("    ", "Voltage", virtual_phase->get_voltage_sensor());
+  }
 
   for (auto *ct_clamp : this->ct_clamps_) {
     ESP_LOGCONFIG(TAG, "  CT Clamp");
-    ESP_LOGCONFIG(TAG, "    Phase Calibration: %f", ct_clamp->get_phase()->get_calibration());
+    ESP_LOGCONFIG(TAG, "    Phase Type: %s", ct_clamp->get_phase()->is_virtual() ? "virtual" : "physical");
     ESP_LOGCONFIG(TAG, "    CT Port Index: %d", ct_clamp->get_input_port());
     LOG_SENSOR("    ", "Power", ct_clamp->get_power_sensor());
     LOG_SENSOR("    ", "Current", ct_clamp->get_current_sensor());
@@ -81,6 +87,9 @@ void EmporiaVueComponent::update() {
   for (auto *phase : this->phases_) {
     phase->update_from_reading(sensor_reading);
   }
+  for (auto *virtual_phase : this->virtual_phases_) {
+    virtual_phase->update_from_reading(sensor_reading);
+  }
   for (auto *ct_clamp : this->ct_clamps_) {
     ct_clamp->update_from_reading(sensor_reading);
   }
@@ -100,8 +109,7 @@ static inline bool is_mains_port(CTInputPort port) {
 
 void PhaseConfig::update_from_reading(const SensorReading &sensor_reading) {
   if (this->voltage_sensor_) {
-    float calibrated_voltage = sensor_reading.voltage[this->input_wire_] * this->calibration_;
-    this->voltage_sensor_->publish_state(calibrated_voltage);
+    this->voltage_sensor_->publish_state(this->extract_calibrated_voltage(sensor_reading));
   }
 
   uint16_t raw_frequency = sensor_reading.frequency;
@@ -119,7 +127,11 @@ void PhaseConfig::update_from_reading(const SensorReading &sensor_reading) {
   }
 }
 
-int32_t PhaseConfig::extract_power_for_phase(const ReadingPowerEntry &power_entry) {
+float PhaseConfig::extract_calibrated_voltage(const SensorReading &sensor_reading) const {
+  return sensor_reading.voltage[this->input_wire_] * this->calibration_;
+}
+
+int32_t PhaseConfig::extract_power_for_phase(const ReadingPowerEntry &power_entry) const {
   switch (this->input_wire_) {
     case PhaseInputWire::BLACK:
       return power_entry.phase_black;
@@ -133,11 +145,31 @@ int32_t PhaseConfig::extract_power_for_phase(const ReadingPowerEntry &power_entr
   }
 }
 
+float PhaseConfig::get_calibrated_power(const ReadingPowerEntry &power_entry, float correction_factor) const {
+  return (this->extract_power_for_phase(power_entry) * this->calibration_) / correction_factor;
+}
+
+void VirtualPhaseConfig::update_from_reading(const SensorReading &sensor_reading) {
+  if (this->voltage_sensor_) {
+    float voltage = this->phase_a_->extract_calibrated_voltage(sensor_reading) +
+                    this->phase_b_->extract_calibrated_voltage(sensor_reading);
+    this->voltage_sensor_->publish_state(voltage);
+  }
+}
+
+int32_t VirtualPhaseConfig::extract_power_for_phase(const ReadingPowerEntry &power_entry) const {
+  return this->phase_a_->extract_power_for_phase(power_entry) - this->phase_b_->extract_power_for_phase(power_entry);
+}
+
+float VirtualPhaseConfig::get_calibrated_power(const ReadingPowerEntry &power_entry, float correction_factor) const {
+  return this->phase_a_->get_calibrated_power(power_entry, correction_factor) -
+         this->phase_b_->get_calibrated_power(power_entry, correction_factor);
+}
+
 void CTClampConfig::update_from_reading(const SensorReading &sensor_reading) {
   if (this->power_sensor_) {
     ReadingPowerEntry power_entry = sensor_reading.power[this->input_port_];
-    int32_t raw_power = this->phase_->extract_power_for_phase(power_entry);
-    float calibrated_power = this->get_calibrated_power(raw_power);
+    float calibrated_power = this->phase_->get_calibrated_power(power_entry, this->get_correction_factor());
     this->power_sensor_->publish_state(calibrated_power);
   }
   if (this->current_sensor_) {
@@ -153,12 +185,8 @@ void CTClampConfig::update_from_reading(const SensorReading &sensor_reading) {
   }
 }
 
-float CTClampConfig::get_calibrated_power(int32_t raw_power) const {
-  float calibration = this->phase_->get_calibration();
-
-  float correction_factor = (this->input_port_ < 3) ? 5.5 : 22;
-
-  return (raw_power * calibration) / correction_factor;
+float CTClampConfig::get_correction_factor() const {
+  return (this->input_port_ < 3) ? 5.5f : 22.0f;
 }
 
 }  // namespace emporia_vue

--- a/esphome/components/emporia_vue/emporia_vue.h
+++ b/esphome/components/emporia_vue/emporia_vue.h
@@ -36,6 +36,8 @@ struct __attribute__((__packed__)) SensorReading {
 };
 
 class PhaseConfig;
+class VirtualPhaseConfig;
+class PhaseTargetConfig;
 class CTClampConfig;
 
 class EmporiaVueComponent : public PollingComponent, public i2c::I2CDevice {
@@ -45,6 +47,9 @@ class EmporiaVueComponent : public PollingComponent, public i2c::I2CDevice {
   float get_setup_priority() const override { return esphome::setup_priority::HARDWARE; }
 
   void set_phases(std::vector<PhaseConfig *> phases) { this->phases_ = std::move(phases); }
+  void set_virtual_phases(std::vector<VirtualPhaseConfig *> virtual_phases) {
+    this->virtual_phases_ = std::move(virtual_phases);
+  }
   void set_ct_clamps(std::vector<CTClampConfig *> ct_clamps) { this->ct_clamps_ = std::move(ct_clamps); }
 
   void update() override;
@@ -54,6 +59,7 @@ class EmporiaVueComponent : public PollingComponent, public i2c::I2CDevice {
  protected:
   uint8_t last_sequence_num_ = 0;
   std::vector<PhaseConfig *> phases_;
+  std::vector<VirtualPhaseConfig *> virtual_phases_;
   std::vector<CTClampConfig *> ct_clamps_;
   CallbackManager<void()> callback_;
 };
@@ -64,7 +70,15 @@ enum PhaseInputWire : uint8_t {
   BLUE = 2,
 };
 
-class PhaseConfig {
+class PhaseTargetConfig {
+ public:
+  virtual ~PhaseTargetConfig() = default;
+  virtual int32_t extract_power_for_phase(const ReadingPowerEntry &power_entry) const = 0;
+  virtual float get_calibrated_power(const ReadingPowerEntry &power_entry, float correction_factor) const = 0;
+  virtual bool is_virtual() const = 0;
+};
+
+class PhaseConfig : public PhaseTargetConfig {
  public:
   void set_input_wire(PhaseInputWire input_wire) { this->input_wire_ = input_wire; }
   PhaseInputWire get_input_wire() const { return this->input_wire_; }
@@ -78,8 +92,11 @@ class PhaseConfig {
   sensor::Sensor *get_phase_angle_sensor() const { return this->phase_angle_sensor_; }
 
   void update_from_reading(const SensorReading &sensor_reading);
+  float extract_calibrated_voltage(const SensorReading &sensor_reading) const;
 
-  int32_t extract_power_for_phase(const ReadingPowerEntry &power_entry);
+  int32_t extract_power_for_phase(const ReadingPowerEntry &power_entry) const override;
+  float get_calibrated_power(const ReadingPowerEntry &power_entry, float correction_factor) const override;
+  bool is_virtual() const override { return false; }
 
  protected:
   PhaseInputWire input_wire_;
@@ -87,6 +104,27 @@ class PhaseConfig {
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *frequency_sensor_{nullptr};
   sensor::Sensor *phase_angle_sensor_{nullptr};
+};
+
+class VirtualPhaseConfig : public PhaseTargetConfig {
+ public:
+  void set_phase_a(PhaseConfig *phase_a) { this->phase_a_ = phase_a; }
+  const PhaseConfig *get_phase_a() const { return this->phase_a_; }
+  void set_phase_b(PhaseConfig *phase_b) { this->phase_b_ = phase_b; }
+  const PhaseConfig *get_phase_b() const { return this->phase_b_; }
+  void set_voltage_sensor(sensor::Sensor *voltage_sensor) { this->voltage_sensor_ = voltage_sensor; }
+  sensor::Sensor *get_voltage_sensor() const { return this->voltage_sensor_; }
+
+  void update_from_reading(const SensorReading &sensor_reading);
+
+  int32_t extract_power_for_phase(const ReadingPowerEntry &power_entry) const override;
+  float get_calibrated_power(const ReadingPowerEntry &power_entry, float correction_factor) const override;
+  bool is_virtual() const override { return true; }
+
+ protected:
+  PhaseConfig *phase_a_{nullptr};
+  PhaseConfig *phase_b_{nullptr};
+  sensor::Sensor *voltage_sensor_{nullptr};
 };
 
 enum CTInputPort : uint8_t {
@@ -119,8 +157,8 @@ enum CTInputPort : uint8_t {
 
 class CTClampConfig : public sensor::Sensor {
  public:
-  void set_phase(PhaseConfig *phase) { this->phase_ = phase; };
-  const PhaseConfig *get_phase() const { return this->phase_; }
+  void set_phase(PhaseTargetConfig *phase) { this->phase_ = phase; };
+  const PhaseTargetConfig *get_phase() const { return this->phase_; }
   void set_input_port(CTInputPort input_port) { this->input_port_ = input_port; };
   CTInputPort get_input_port() const { return this->input_port_; }
   void set_power_sensor(sensor::Sensor *power_sensor) { this->power_sensor_ = power_sensor; }
@@ -129,10 +167,10 @@ class CTClampConfig : public sensor::Sensor {
   sensor::Sensor *get_current_sensor() const { return this->current_sensor_; }
 
   void update_from_reading(const SensorReading &sensor_reading);
-  float get_calibrated_power(int32_t raw_power) const;
+  float get_correction_factor() const;
 
  protected:
-  PhaseConfig *phase_;
+  PhaseTargetConfig *phase_;
   CTInputPort input_port_;
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};

--- a/esphome/components/emporia_vue/sensor.py
+++ b/esphome/components/emporia_vue/sensor.py
@@ -28,6 +28,8 @@ CONF_CT_CLAMPS = "ct_clamps"
 CONF_PHASES = "phases"
 CONF_PHASE_ID = "phase_id"
 CONF_VARIANT = "variant"
+CONF_VIRTUAL_PHASES = "virtual_phases"
+CONF_COMBINE = "combine"
 
 CONF_ON_UPDATE = "on_update"
 
@@ -40,7 +42,9 @@ emporia_vue_ns = cg.esphome_ns.namespace("emporia_vue")
 EmporiaVueComponent = emporia_vue_ns.class_(
     "EmporiaVueComponent", cg.PollingComponent, i2c.I2CDevice
 )
-PhaseConfig = emporia_vue_ns.class_("PhaseConfig")
+PhaseTargetConfig = emporia_vue_ns.class_("PhaseTargetConfig")
+PhaseConfig = emporia_vue_ns.class_("PhaseConfig", PhaseTargetConfig)
+VirtualPhaseConfig = emporia_vue_ns.class_("VirtualPhaseConfig", PhaseTargetConfig)
 CTClampConfig = emporia_vue_ns.class_("CTClampConfig")
 
 # Trigger for after statistics sensors are updated
@@ -81,7 +85,7 @@ CT_INPUT = {
 
 SCHEMA_CT_CLAMP = {
     cv.GenerateID(): cv.declare_id(CTClampConfig),
-    cv.Required(CONF_PHASE_ID): cv.use_id(PhaseConfig),
+    cv.Required(CONF_PHASE_ID): cv.use_id(PhaseTargetConfig),
     cv.Required(CONF_INPUT): cv.enum(CT_INPUT),
     cv.Optional(CONF_POWER): sensor.sensor_schema(
         unit_of_measurement=UNIT_WATT,
@@ -153,11 +157,41 @@ def validate_phases(val):
     return base_validated
 
 
+def validate_virtual_phases(val):
+    base_validated = cv.Schema(
+        cv.ensure_list(
+            {
+                cv.Required(CONF_ID): cv.declare_id(VirtualPhaseConfig),
+                cv.Required(CONF_COMBINE): cv.All(
+                    cv.ensure_list(cv.use_id(PhaseConfig)),
+                    cv.Length(min=2, max=2),
+                ),
+                cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_VOLT,
+                    device_class=DEVICE_CLASS_VOLTAGE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                    accuracy_decimals=1,
+                ),
+            }
+        )
+    )(val)
+
+    for i, phase in enumerate(base_validated):
+        if phase[CONF_COMBINE][0] == phase[CONF_COMBINE][1]:
+            raise cv.Invalid(
+                "Virtual phase combine entries must reference two distinct phase ids",
+                path=[i, CONF_COMBINE],
+            )
+
+    return base_validated
+
+
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(EmporiaVueComponent),
             cv.Required(CONF_PHASES): validate_phases,
+            cv.Optional(CONF_VIRTUAL_PHASES, default=[]): validate_virtual_phases,
             cv.Required(CONF_CT_CLAMPS): cv.ensure_list(SCHEMA_CT_CLAMP),
             cv.Optional(CONF_VARIANT, default="vue2"): cv.one_of("vue2", "vue3", lower=True),
             cv.Optional(CONF_ON_UPDATE): automation.validate_automation(
@@ -205,6 +239,23 @@ async def to_code(config):
 
         phases.append(phase_var)
     cg.add(var.set_phases(phases))
+
+    virtual_phases = []
+    for virtual_phase_config in config[CONF_VIRTUAL_PHASES]:
+        virtual_phase_var = cg.new_Pvariable(
+            virtual_phase_config[CONF_ID], VirtualPhaseConfig()
+        )
+        phase_a_var = await cg.get_variable(virtual_phase_config[CONF_COMBINE][0])
+        phase_b_var = await cg.get_variable(virtual_phase_config[CONF_COMBINE][1])
+        cg.add(virtual_phase_var.set_phase_a(phase_a_var))
+        cg.add(virtual_phase_var.set_phase_b(phase_b_var))
+
+        if CONF_VOLTAGE in virtual_phase_config:
+            voltage_sensor = await sensor.new_sensor(virtual_phase_config[CONF_VOLTAGE])
+            cg.add(virtual_phase_var.set_voltage_sensor(voltage_sensor))
+
+        virtual_phases.append(virtual_phase_var)
+    cg.add(var.set_virtual_phases(virtual_phases))
 
     ct_clamps = []
     for ct_config in config[CONF_CT_CLAMPS]:


### PR DESCRIPTION
This adds support for North American split-phase 240V circuits. This allows a "virtual phase" to be configured from two actual phases, which can then be referenced as a phase for CT clamp power calculation or for publishing a derived voltage sensor. This is more accurate than the old multiply-by-2 workaround since it adds together the calculated power for each of the constituent phases. Note that this approach still uses a single CT, so is only accurate for circuits that have no neutral current.

Example:

```yaml
sensor:
  - platform: emporia_vue
    phases:
      - id: leg_1
        input: BLACK
      - id: leg_2
        input: RED

    virtual_phases:
      - id: leg_1_2
        combine: [leg_1, leg_2]
        voltage:
          name: "L1+L2 Voltage"

    ct_clamps:
      - input: "4"
        phase_id: leg_1_2
        power:
          id: cir4
```

I've also updated `README.old.md` even though it's the old readme. Website edits may be required as well?